### PR TITLE
add regist_type to const inputs

### DIFF
--- a/lib/gmo/const.rb
+++ b/lib/gmo/const.rb
@@ -104,6 +104,7 @@ module GMO
       :receipts_disp_13      => "ReceiptsDisp13",
       :recurring_id          => "RecurringID",
       :redirect_url          => "RedirectURL",
+      :regist_type           => "RegistType",
       :register_disp_1       => "RegisterDisp1",
       :register_disp_2       => "RegisterDisp2",
       :register_disp_3       => "RegisterDisp3",


### PR DESCRIPTION
`register_recurring_credit` 等で使用するパラメーターのconstへの追加