### PR TITLE
Search recurring result file api

### DIFF
--- a/lib/gmo.rb
+++ b/lib/gmo.rb
@@ -39,6 +39,9 @@ module GMO
         end
         # Parse the body as Query string
         response = Rack::Utils.parse_nested_query(result.body.to_s)
+
+        return response if path == '/payment/SearchRecurringResultFile.idPass'
+
         # converting to UTF-8
         body = response = Hash[response.map { |k,v| [k, NKF.nkf('-w',v)] }]
         # Check for errors if provided a error_checking_block

--- a/lib/gmo.rb
+++ b/lib/gmo.rb
@@ -39,8 +39,8 @@ module GMO
         end
         # Parse the body as Query string
         response = Rack::Utils.parse_nested_query(result.body.to_s)
-
-        return response if path == '/payment/SearchRecurringResultFile.idPass'
+  
+        return response.keys.first if path == '/payment/SearchRecurringResultFile.idPass'
 
         # converting to UTF-8
         body = response = Hash[response.map { |k,v| [k, NKF.nkf('-w',v)] }]

--- a/lib/gmo.rb
+++ b/lib/gmo.rb
@@ -39,11 +39,15 @@ module GMO
         end
         # Parse the body as Query string
         response = Rack::Utils.parse_nested_query(result.body.to_s)
-  
-        return response.keys.first if path == '/payment/SearchRecurringResultFile.idPass'
 
-        # converting to UTF-8
-        body = response = Hash[response.map { |k,v| [k, NKF.nkf('-w',v)] }]
+        if path == '/payment/SearchRecurringResultFile.idPass'
+          filtered_response = response.keys.first
+        else
+          # converting to UTF-8
+          filtered_response = Hash[response.map { |k,v| [k, NKF.nkf('-w',v)] }]
+        end
+
+        body = response = filtered_response
         # Check for errors if provided a error_checking_block
         yield(body) if error_checking_block
         # Return result

--- a/lib/gmo/const.rb
+++ b/lib/gmo/const.rb
@@ -35,6 +35,7 @@ module GMO
       :card_pass             => "CardPass",
       :card_seq              => "CardSeq",
       :charge_day            => "ChargeDay",
+      :charge_date           => "ChargeDate",
       :charge_month          => "ChargeMonth",
       :charge_start_date     => "ChargeStartDate",
       :charge_stop_date      => "ChargeStopDate",

--- a/lib/gmo/shop_api.rb
+++ b/lib/gmo/shop_api.rb
@@ -802,6 +802,18 @@ module GMO
         post_request name, options
       end
 
+      ### @param ###
+      # Method
+      # ChargeDate
+      ### @return ###
+      # String (csv format)
+      def search_recurring_result_file(options)
+        name = "SearchRecurringResultFile.idPass"
+        required = [:method, :charge_date]
+        assert_required_options(required, options)
+        post_request name, options
+      end
+
       ### @params ###
       # AccessID
       # AccessPass


### PR DESCRIPTION
継続決済csv形式のstringを返すAPIへのリクエスト実装

※ 分岐が乱暴で申し訳ない・・！が、他にどのようなケースがあるかの把握が作業コスト的に難しいため、一旦pathでの分岐とさせてください。